### PR TITLE
Throttle window.onresize event

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ export const SMALL = 2;
 export const MEDIUM = 3;
 export const LARGE = 4;
 
-export function initReduxDeviceType({ dispatch }, customWidths = {}) {
+export function initReduxDeviceType(store, customWidths = {}) {
 
   const setDeviceType = () => {
     let deviceType = IPHONE_RETINA;
@@ -17,7 +17,8 @@ export function initReduxDeviceType({ dispatch }, customWidths = {}) {
     else if (window.innerWidth >= (customWidths.small || 768)) deviceType = SMALL;
     else if (window.innerWidth >= (customWidths.extraSmall || 480)) deviceType = EXTRA_SMALL;
 
-    dispatch({ type: SET_DEVICE_TYPE, deviceType });
+    if (store.getState() === deviceType) return;
+    store.dispatch({ type: SET_DEVICE_TYPE, deviceType });
   };
 
   setDeviceType(); //initial value

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export function initReduxDeviceType({ dispatch }, customWidths = {}) {
   };
 
   setDeviceType(); //initial value
-  window.onresize = throttle(setDeviceType, 100);
+  window.onresize = throttle(100)(setDeviceType);
 }
 
 export const deviceTypeReducer = (state = null, action) => {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const debounce = require('lodash/fp/debounce');
+
 const SET_DEVICE_TYPE = 'SET_DEVICE_TYPE';
 
 export const IPHONE_RETINA = 0;
@@ -19,7 +21,7 @@ export function initReduxDeviceType({ dispatch }, customWidths = {}) {
   };
 
   setDeviceType(); //initial value
-  window.onresize = setDeviceType;
+  window.onresize = debounce(setDeviceType, 100);
 }
 
 export const deviceTypeReducer = (state = null, action) => {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const debounce = require('lodash/fp/debounce');
+const throttle = require('lodash/fp/throttle');
 
 const SET_DEVICE_TYPE = 'SET_DEVICE_TYPE';
 
@@ -21,7 +21,7 @@ export function initReduxDeviceType({ dispatch }, customWidths = {}) {
   };
 
   setDeviceType(); //initial value
-  window.onresize = debounce(setDeviceType, 100);
+  window.onresize = throttle(setDeviceType, 100);
 }
 
 export const deviceTypeReducer = (state = null, action) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "redux-device-type",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/matthiasklan/redux-device-type/issues"
   },
-  "homepage": "https://github.com/matthiasklan/redux-device-type#readme"
+  "homepage": "https://github.com/matthiasklan/redux-device-type#readme",
+  "dependencies": {
+    "lodash": "^4.17.4"
+  }
 }


### PR DESCRIPTION
It would be better to throttle `window.onresize` event cb to reduce CPU usage.
And also do not `dispatch` unless state's unchanged.